### PR TITLE
fix(deps): provider 1.70 required for CBR for SM in apps example

### DIFF
--- a/examples/apps/version.tf
+++ b/examples/apps/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.63.0"
+      version = ">= 1.70.0"
     }
   }
 }

--- a/examples/apps/version.tf
+++ b/examples/apps/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.70.0"
+      version = ">= 1.70.0, < 2.0.0"
     }
   }
 }

--- a/examples/jobs/version.tf
+++ b/examples/jobs/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.63.0, < 2.0.0"
+      version = "1.63.0"
     }
   }
 }

--- a/examples/jobs/version.tf
+++ b/examples/jobs/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.62.0, < 2.0.0"
+      version = "1.63.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

Secrets manager changes introduced in #125 will require IBM provider 1.70.0 for CBR for private cert. The apps example needs to bump to at least that version. The jobs example will need to validate the minimal level.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
