### PR TITLE
fix: added cbr_rules in apps DA

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -240,6 +240,9 @@
             },
             {
               "key": "bindings"
+            },
+            {
+              "key": "cbr_rules"
             }
           ]
         },

--- a/solutions/apps/DA-cbr_rules.md
+++ b/solutions/apps/DA-cbr_rules.md
@@ -37,12 +37,12 @@ The `cbr_rules` input variable allows you to provide a rule for the target servi
 cbr_rules = [
   {
   description = "Code Engine can be accessed from xyz"
-  account_id = "defc0df06b644a9cabc6e44f55b3880s."
+  account_id = "defc0df06b644a9cabc6e44f55b3880s"
   rule_contexts= [{
       attributes = [
                 {
-                              "name" : "endpointType",
-                              "value" : "private"
+                  name : "endpointType",
+                  value : "private"
                 },
                 {
                   name  = "networkZoneId"

--- a/solutions/apps/DA-cbr_rules.md
+++ b/solutions/apps/DA-cbr_rules.md
@@ -1,0 +1,62 @@
+# Configuring complex inputs for Code Engine in IBM Cloud projects
+
+Several optional input variables in the IBM Cloud [Code Engine deployable architecture](https://cloud.ibm.com/catalog#deployable_architecture) use complex object types. You specify these inputs when you configure deployable architecture.
+
+* Context-Based Restrictions Rules (`cbr_rules`)
+
+
+## Rules For Context-Based Restrictions <a name="cbr_rules"></a>
+
+The `cbr_rules` input variable allows you to provide a rule for the target service to enforce access restrictions for the service based on the context of access requests. Contexts are criteria that include the network location of access requests, the endpoint type from where the request is sent, etc.
+
+- Variable name: `cbr_rules`.
+- Type: A list of objects. Allows only one object representing a rule for the target service
+- Default value: An empty list (`[]`).
+
+### Options for cbr_rules
+
+  - `description` (required): The description of the rule to create.
+  - `account_id` (required): The IBM Cloud Account ID
+  - `rule_contexts` (required): (List) The contexts the rule applies to
+      - `attributes` (optional): (List) Individual context attributes
+        - `name` (required): The attribute name.
+        - `value`(required): The attribute value.
+
+  - `enforcement_mode` (required): The rule enforcement mode can have the following values:
+      - `enabled` - The restrictions are enforced and reported. This is the default.
+      - `disabled` - The restrictions are disabled. Nothing is enforced or reported.
+      - `report` - The restrictions are evaluated and reported, but not enforced.
+  - `operations` (optional): The operations this rule applies to
+    - `api_types`(required): (List) The API types this rule applies to.
+        - `api_type_id`(required):The API type ID
+
+
+### Example Rule For Context-Based Restrictions Configuration
+
+```hcl
+cbr_rules = [
+  {
+  description = "Code Engine can be accessed from xyz"
+  account_id = "defc0df06b644a9cabc6e44f55b3880s."
+  rule_contexts= [{
+      attributes = [
+                {
+                              "name" : "endpointType",
+                              "value" : "private"
+                },
+                {
+                  name  = "networkZoneId"
+                  value = "93a51a1debe2674193217209601dde6f" # pragma: allowlist secret
+                }
+        ]
+     }
+   ]
+  enforcement_mode = "enabled"
+  operations = [{
+    api_types = [{
+     api_type_id = "crn:v1:bluemix:public:context-based-restrictions::::api-type:"
+      }]
+    }]
+  }
+]
+```

--- a/solutions/apps/main.tf
+++ b/solutions/apps/main.tf
@@ -18,6 +18,7 @@ module "code_engine" {
   resource_group_id   = module.resource_group.resource_group_id
   project_name        = var.project_name
   existing_project_id = var.existing_project_id
+  cbr_rules           = var.cbr_rules
   apps = {
     # tflint-ignore: terraform_deprecated_interpolation
     "${var.app_name}" = {

--- a/solutions/apps/variables.tf
+++ b/solutions/apps/variables.tf
@@ -240,3 +240,23 @@ variable "bindings" {
   }))
   default = {}
 }
+
+variable "cbr_rules" {
+  type = list(object({
+    description = string
+    account_id  = string
+    rule_contexts = list(object({
+      attributes = optional(list(object({
+        name  = string
+        value = string
+    }))) }))
+    enforcement_mode = string
+    operations = optional(list(object({
+      api_types = list(object({
+        api_type_id = string
+      }))
+    })))
+  }))
+  description = "The list of context-based restrictions rules to create.[Learn more](https://github.com/terraform-ibm-modules/terraform-ibm-code-engine/blob/main/solutions/project/DA-cbr_rules.md)"
+  default     = []
+}

--- a/solutions/project/DA-cbr_rules.md
+++ b/solutions/project/DA-cbr_rules.md
@@ -37,12 +37,12 @@ The `cbr_rules` input variable allows you to provide a rule for the target servi
 cbr_rules = [
   {
   description = "Code Engine can be accessed from xyz"
-  account_id = "defc0df06b644a9cabc6e44f55b3880s."
+  account_id = "defc0df06b644a9cabc6e44f55b3880s"
   rule_contexts= [{
       attributes = [
                 {
-                              "name" : "endpointType",
-                              "value" : "private"
+                  name : "endpointType",
+                  value : "private"
                 },
                 {
                   name  = "networkZoneId"


### PR DESCRIPTION
### Description

Added cbr_rules variable in apps DA.
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-code-engine/issues/163)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- cbr_rules varibles now exposed to the apps DA.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
