### PR TITLE
fix: wait till build run is finished before next resource is executed

### DIFF
--- a/solutions/project/main.tf
+++ b/solutions/project/main.tf
@@ -89,9 +89,9 @@ module "build" {
   timeout            = each.value.timeout
 }
 
-resource "null_resource" "run_build" {
-  count      = length(local.updated_builds) > 0 ? 1 : 0
+resource "terraform_data" "run_build" {
   depends_on = [module.build]
+
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = "${path.module}/scripts/build-run.sh"

--- a/solutions/project/scripts/build-run.sh
+++ b/solutions/project/scripts/build-run.sh
@@ -32,7 +32,24 @@ ibmcloud login -r "${REGION}" -g "${RESOURCE_GROUP_ID}" --quiet
 ibmcloud ce project select -n "${CE_PROJECT_NAME}"
 
 # run a build for all builds
+# we check for status build to be succeeded before we finish with script.
+# This is needed in a case we deploy app, which needs build_run to be finished.
 for build in $BUILDS; do
-    echo "$build"
-    ibmcloud ce buildrun submit --build  "$build"
+    echo "Submitting build: $build"
+    run_build_name=$(ibmcloud ce buildrun submit --build build-adn-11 --output json | jq -r '.name')
+
+    echo "Waiting for build run $run_build_name to complete..."
+    while true; do
+        status=$(ibmcloud ce buildrun get --name "$run_build_name" --output json | jq -r '.status')
+        echo "Status: $status"
+        if [[ "$status" == "succeeded" ]]; then
+            echo "Build $build succeeded"
+            break
+        elif [[ "$status" == "Failed" || "$status" == "Error" ]]; then
+            echo "Build $build failed"
+            exit 1
+        else
+            sleep 10
+        fi
+    done
 done

--- a/solutions/project/scripts/build-run.sh
+++ b/solutions/project/scripts/build-run.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# max wait time = 60 × 10s = 10 minutes
+MAX_RETRIES=60
+RETRY_INTERVAL=10  # seconds
+
 if [[ -z "${IBMCLOUD_API_KEY}" ]]; then
   echo "IBMCLOUD_API_KEY is required" >&2
   exit 1
@@ -36,20 +40,29 @@ ibmcloud ce project select -n "${CE_PROJECT_NAME}"
 # This is needed in a case we deploy app, which needs build_run to be finished.
 for build in $BUILDS; do
     echo "Submitting build: $build"
-    run_build_name=$(ibmcloud ce buildrun submit --build build-adn-11 --output json | jq -r '.name')
+    run_build_name=$(ibmcloud ce buildrun submit --build "$build" --output json | jq -r '.name')
 
     echo "Waiting for build run $run_build_name to complete..."
+    retries=0
     while true; do
         status=$(ibmcloud ce buildrun get --name "$run_build_name" --output json | jq -r '.status')
         echo "Status: $status"
         if [[ "$status" == "succeeded" ]]; then
             echo "Build $build succeeded"
             break
+
         elif [[ "$status" == "Failed" || "$status" == "Error" ]]; then
             echo "Build $build failed"
             exit 1
-        else
-            sleep 10
         fi
+
+        #  if max time timeout then finish with error
+        if [[ $retries -ge $MAX_RETRIES ]]; then
+            echo "Build $build did not complete after $MAX_RETRIES retries. Timing out."
+            exit 1
+        fi
+
+        retries=$((retries + 1))
+        sleep "$RETRY_INTERVAL"
     done
 done

--- a/solutions/project/version.tf
+++ b/solutions/project/version.tf
@@ -10,9 +10,5 @@ terraform {
       source  = "hashicorp/external"
       version = "2.3.5"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "3.2.4"
-    }
   }
 }


### PR DESCRIPTION
### Description
There is an issue with build_run script, because doesn't wait till build run is really completed. We had to improve the script to add check the status.


```hcl
module.build["build-adn-11"].ibm_code_engine_build.ce_build: Creation complete after 0s [id=406e1b6f-09a6-4b54-9757-4958eb6cb706/build-adn-11]
terraform_data.run_build: Creating...
terraform_data.run_build: Provisioning with 'local-exec'...
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build: Still creating... [10s elapsed]
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build: Still creating... [20s elapsed]
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build: Still creating... [30s elapsed]
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build: Still creating... [40s elapsed]
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build: Still creating... [50s elapsed]
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build: Still creating... [1m0s elapsed]
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build (local-exec): (output suppressed due to sensitive value in config)
terraform_data.run_build: Creation complete after 1m7s [id=b8ccea52-6a5c-ab3f-b772-cc40ed9f360a]
module.apps.ibm_code_engine_app.ce_app: Creating...
module.apps.ibm_code_engine_app.ce_app: Still creating... [10s elapsed]
module.apps.ibm_code_engine_app.ce_app: Still creating... [20s elapsed]
module.apps.ibm_code_engine_app.ce_app: Still creating... [30s elapsed]
module.apps.ibm_code_engine_app.ce_app: Still creating... [40s elapsed]
module.apps.ibm_code_engine_app.ce_app: Still creating... [50s elapsed]
module.apps.ibm_code_engine_app.ce_app: Still creating... [1m0s elapsed]
module.apps.ibm_code_engine_app.ce_app: Creation complete after 1m1s [id=406e1b6f-09a6-4b54-9757-4958eb6cb706/apptest1]

Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

```
<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
