### PR TITLE
fix: do not run build run if builds are not passed in

### DIFF
--- a/solutions/project/main.tf
+++ b/solutions/project/main.tf
@@ -91,6 +91,7 @@ module "build" {
 
 resource "terraform_data" "run_build" {
   depends_on = [module.build]
+  count      = length(local.updated_builds) > 0 ? 1 : 0
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -190,9 +190,10 @@ func TestUpgradeCEProjectDA(t *testing.T) {
 	t.Parallel()
 
 	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
-		Testing:      t,
-		TerraformDir: projectSolutionsDir,
-		Prefix:       "ce-da",
+		Testing:                    t,
+		TerraformDir:               projectSolutionsDir,
+		Prefix:                     "ce-da",
+		CheckApplyResultForUpgrade: true,
 	})
 
 	options.TerraformVars = map[string]interface{}{
@@ -364,4 +365,26 @@ func writeTfvarsFile(t *testing.T, path string, vars map[string]interface{}) err
 		t.Fatalf("Failed to write tfvars file: %v", err)
 	}
 	return err
+}
+
+// test edge case when only empty project is created
+func TestCEProjectDABasic(t *testing.T) {
+	t.Parallel()
+
+	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
+		Testing:      t,
+		TerraformDir: projectSolutionsDir,
+		Prefix:       "ce-da-empty",
+	})
+
+	options.TerraformVars = map[string]interface{}{
+		"existing_resource_group_name": resourceGroup,
+		"provider_visibility":          "public",
+		"prefix":                       options.Prefix,
+		"project_name":                 "proj-test",
+	}
+
+	output, err := options.RunTestConsistency()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
 }


### PR DESCRIPTION
### Description
catalog pipeline failed

```
2025/06/26 20:08:34 Terraform apply | Error: local-exec provisioner error
 2025/06/26 20:08:34 Terraform apply | 
 2025/06/26 20:08:34 Terraform apply |   with terraform_data.run_build,
 2025/06/26 20:08:34 Terraform apply |   on main.tf line 95, in resource "terraform_data" "run_build":
 2025/06/26 20:08:34 Terraform apply |   95:   provisioner "local-exec" {
 2025/06/26 20:08:34 Terraform apply | 
 2025/06/26 20:08:34 Terraform apply | Error running command './scripts/build-run.sh': exit status 1. Output: BUILDS
 2025/06/26 20:08:34 Terraform apply | is required
 ```
<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
