### PR TITLE
fix: random region selection in test

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/common"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testschematic"
@@ -32,19 +33,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-var validRegions = []string{
-	"us-south",
-	"us-east",
-	"ca-tor",
-	"eu-de",
-	"eu-gb",
-	"eu-es",
-	"jp-tok",
-	"jp-osa",
-	"au-syd",
-	"br-sao",
 }
 
 func setupJobsExampleOptions(t *testing.T, prefix string, terraformDir string) *testhelper.TestOptions {
@@ -178,7 +166,14 @@ func TestRunBuildExampleInSchematics(t *testing.T) {
 		WaitJobCompleteMinutes: 60,
 	})
 
-	region := validRegions[common.CryptoIntn(len(validRegions))]
+	// Verify ibmcloud_api_key variable is set
+	checkVariable := "TF_VAR_ibmcloud_api_key"
+	val, present := os.LookupEnv(checkVariable)
+	require.True(t, present, checkVariable+" environment variable not set")
+	require.NotEqual(t, "", val, checkVariable+" environment variable is empty")
+
+	// Programmatically determine region to use based on availability
+	region, _ := testhelper.GetBestVpcRegion(val, "../common-dev-assets/common-go-assets/cloudinfo-region-vpc-gen2-prefs.yaml", "eu-de")
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -34,6 +34,19 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+var validRegions = []string{
+	"us-south",
+	"us-east",
+	"ca-tor",
+	"eu-de",
+	"eu-gb",
+	"eu-es",
+	"jp-tok",
+	"jp-osa",
+	"au-syd",
+	"br-sao",
+}
+
 func setupJobsExampleOptions(t *testing.T, prefix string, terraformDir string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
 		Testing:       t,
@@ -164,11 +177,14 @@ func TestRunBuildExampleInSchematics(t *testing.T) {
 		DeleteWorkspaceOnFail:  false,
 		WaitJobCompleteMinutes: 60,
 	})
+
+	region := validRegions[common.CryptoIntn(len(validRegions))]
+
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "resource_group", Value: options.ResourceGroup, DataType: "string"},
 		{Name: "prefix", Value: options.Prefix + "-b", DataType: "string"},
-		{Name: "region", Value: "eu-gb", DataType: "string"},
+		{Name: "region", Value: region, DataType: "string"},
 	}
 
 	err := options.RunSchematicTest()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -168,7 +168,7 @@ func TestRunBuildExampleInSchematics(t *testing.T) {
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "resource_group", Value: options.ResourceGroup, DataType: "string"},
 		{Name: "prefix", Value: options.Prefix + "-b", DataType: "string"},
-		{Name: "region", Value: options.Region, DataType: "string"},
+		{Name: "region", Value: "eu-gb", DataType: "string"},
 	}
 
 	err := options.RunSchematicTest()


### PR DESCRIPTION
### Description

Hardcode region in test so that the deployment takes place in some other region. https://github.ibm.com/GoldenEye/issues/issues/17565

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [X] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
